### PR TITLE
fix operator precedence issue

### DIFF
--- a/src/paillier.py
+++ b/src/paillier.py
@@ -50,7 +50,7 @@ def encrypt(m, key):
     n, 𝜻 = key
     r = uniform(1, n - 1)
     f = primes.power_mod
-    return (f(𝜻, m, n * n) * f(r, n, n * n)) % n * n
+    return (f(𝜻, m, n * n) * f(r, n, n * n)) % (n * n)
 
 def decrypt(c, key):
     n, 𝝀, u = key
@@ -81,6 +81,9 @@ def main():
     m = ""
     while not m in ["Quit", "quit", "Q", "q", "Exit", "exit"]:
         m = input("?? ")
+        if primes.encode(m) >= pub[0]:
+            print("Message is too large!")
+            continue
         c = encrypt(primes.encode(m), pub); print(f"En[{m}] = {c}")
         t = primes.decode(decrypt(c, prv)); print(f"De[{c}] = {t}")
 


### PR DESCRIPTION
`%` and `*` have the same precedence, and are thus evaluated from left-to-right. In order to perform modulus by `n * n`, we wrap it in parentheses.

Also introduce a check to only perform encryption/decryption on messages that fit within the generated public key.